### PR TITLE
Improve memory service with caching and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Mixa Memory Service
+
+This Flask application exposes endpoints for storing and retrieving conversational memories using a GitHub Gist as persistence.
+
+## Environment Variables
+
+The app requires the following environment variables:
+
+- `GITHUB_TOKEN` – Personal access token with permissions to read and update the Gist.
+- `GIST_ID` – Identifier of the Gist containing the `mixa_memories.json` file.
+
+The service will raise an error at startup if these variables are missing.
+
+## Features
+
+- In-memory caching of the Gist content with a 60 second TTL.
+- Automatic pruning of old memories when more than 100 are stored. Older entries are summarized.
+- Embedding-based retrieval endpoint `/memories/relevant?q=<query>` returning the top related memories.
+- Structured logging using Python's logging module.
+
+## Running Tests
+
+Install dependencies and run tests with:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -3,37 +3,71 @@ import os
 import requests
 from flask import Flask, request, jsonify
 from datetime import datetime
+import logging
+from time import time
+from typing import List, Dict
+from collections import Counter
+import math
+
 
 app = Flask(__name__)
 
-GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
-GIST_ID = os.environ.get("GIST_ID")
+
+def require_env(var_name: str) -> str:
+    value = os.environ.get(var_name)
+    if not value:
+        raise EnvironmentError(f"{var_name} environment variable is required")
+    return value
+
+
+GITHUB_TOKEN = require_env("GITHUB_TOKEN")
+GIST_ID = require_env("GIST_ID")
 GIST_FILENAME = "mixa_memories.json"
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(message)s",
+)
 
-# Load memory list from GitHub Gist
-def get_gist_content():
+CACHE_TTL = 60  # seconds
+_cache: Dict[str, any] = {"memories": None, "timestamp": 0}
+MEMORY_LIMIT = 100
+
+
+# Load memory list from GitHub Gist with in-memory cache
+def get_gist_content(force_refresh: bool = False):
+    if (
+        not force_refresh
+        and _cache["memories"] is not None
+        and time() - _cache["timestamp"] < CACHE_TTL
+    ):
+        return _cache["memories"]
+
     headers = {"Authorization": f"token {GITHUB_TOKEN}"}
     url = f"https://api.github.com/gists/{GIST_ID}"
     response = requests.get(url, headers=headers)
 
+    memories = []
     if response.status_code == 200:
         gist_data = response.json()
         files = gist_data.get("files", {})
         if GIST_FILENAME in files:
             file_content = files[GIST_FILENAME]["content"]
             try:
-                return json.loads(file_content)
+                memories = json.loads(file_content)
             except json.JSONDecodeError:
-                return []
-    return []
+                memories = []
+
+    _cache["memories"] = memories
+    _cache["timestamp"] = time()
+    return memories
 
 
 # Update the Gist with new memory list
 def update_gist_content(memories):
     headers = {
         "Authorization": f"token {GITHUB_TOKEN}",
-        "Accept": "application/vnd.github.v3+json"
+        "Accept": "application/vnd.github.v3+json",
     }
     data = {
         "files": {
@@ -45,9 +79,53 @@ def update_gist_content(memories):
     response = requests.patch(
         f"https://api.github.com/gists/{GIST_ID}",
         headers=headers,
-        data=json.dumps(data)
+        data=json.dumps(data),
     )
-    return response.status_code == 200
+    if response.status_code == 200:
+        _cache["memories"] = memories
+        _cache["timestamp"] = time()
+        return True
+    return False
+
+
+def prune_memories(memories: List[Dict], limit: int = MEMORY_LIMIT) -> List[Dict]:
+    if len(memories) <= limit:
+        return memories
+
+    excess = len(memories) - (limit - 1)
+    old_memories = memories[:excess]
+    summary_text = " | ".join(m.get("summary", "") for m in old_memories)
+    summary_memory = {
+        "id": "1",
+        "summary": f"Summary of earlier memories: {summary_text}",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    remaining = [summary_memory] + memories[excess:]
+    for idx, mem in enumerate(remaining, start=1):
+        mem["id"] = str(idx)
+    return remaining
+
+
+def get_relevant_memories(query: str, k: int = 5) -> List[Dict]:
+    memories = get_gist_content()
+    if not memories:
+        return []
+
+    def text_to_vec(text: str) -> Counter:
+        return Counter(text.lower().split())
+
+    def cosine(v1: Counter, v2: Counter) -> float:
+        common = set(v1) & set(v2)
+        num = sum(v1[x] * v2[x] for x in common)
+        sum1 = sum(v ** 2 for v in v1.values())
+        sum2 = sum(v ** 2 for v in v2.values())
+        denom = math.sqrt(sum1) * math.sqrt(sum2)
+        return num / denom if denom else 0.0
+
+    query_vec = text_to_vec(query)
+    scores = [cosine(query_vec, text_to_vec(m.get("summary", ""))) for m in memories]
+    top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]
+    return [memories[i] for i in top_indices]
 
 
 # Save a new memory
@@ -63,11 +141,17 @@ def save_memory():
     new_memory["timestamp"] = datetime.utcnow().isoformat() + "Z"
 
     memories.append(new_memory)
+    memories = prune_memories(memories)
     success = update_gist_content(memories)
     if success:
+        # locate memory after pruning to ensure correct id
+        stored_memory = next(
+            (m for m in memories if m["timestamp"] == new_memory["timestamp"]),
+            new_memory,
+        )
         return jsonify({
             "message": "Memory saved successfully",
-            "memory": new_memory
+            "memory": stored_memory,
         }), 201
     else:
         return jsonify({"error": "Failed to update memory file."}), 500
@@ -79,10 +163,20 @@ def list_memories():
     return jsonify(get_gist_content())
 
 
+@app.route("/memories/relevant", methods=["GET"])
+def relevant_memories_endpoint():
+    query = request.args.get("q")
+    if not query:
+        return jsonify({"error": "Missing query parameter 'q'"}), 400
+    k = int(request.args.get("k", 5))
+    memories = get_relevant_memories(query, k=k)
+    return jsonify(memories)
+
+
 # Get a specific memory by ID
 @app.route("/memories/<memory_id>", methods=["GET"])
 def read_memory_by_id(memory_id):
-    print(f"Requested memory ID: {memory_id}")  # <-- Add this:
+    app.logger.info("Requested memory ID: %s", memory_id)
     memories = get_gist_content()
     for memory in memories:
         if memory.get("id") == memory_id:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.1.2
 flask-cors
 requests
+pytest
 

--- a/tests/test_memory_endpoints.py
+++ b/tests/test_memory_endpoints.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is on path and env vars exist before importing app
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+os.environ.setdefault('GITHUB_TOKEN', 'test-token')
+os.environ.setdefault('GIST_ID', 'test-gist')
+
+import app  # noqa: E402
+
+
+@pytest.fixture
+def client(monkeypatch):
+    test_memories = []
+
+    def fake_get_gist_content(force_refresh=False):
+        return test_memories
+
+    def fake_update_gist_content(memories):
+        nonlocal test_memories
+        test_memories = memories
+        return True
+
+    monkeypatch.setattr(app, 'get_gist_content', fake_get_gist_content)
+    monkeypatch.setattr(app, 'update_gist_content', fake_update_gist_content)
+    return app.app.test_client()
+
+
+def test_post_memory(client):
+    resp = client.post('/memories', json={'summary': 'hello world'})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['memory']['summary'] == 'hello world'
+
+
+def test_get_memories(client):
+    client.post('/memories', json={'summary': 'first'})
+    resp = client.get('/memories')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+
+def test_get_memory_by_id(client):
+    client.post('/memories', json={'summary': 'unique'})
+    resp = client.get('/memories/1')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['summary'] == 'unique'
+    missing = client.get('/memories/999')
+    assert missing.status_code == 404
+
+
+def test_relevant_memories(client):
+    client.post('/memories', json={'summary': 'apple banana'})
+    client.post('/memories', json={'summary': 'cat dog'})
+    resp = client.get('/memories/relevant?q=apple')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) >= 1


### PR DESCRIPTION
## Summary
- validate required GitHub environment variables and add structured logging
- cache gist content, prune old memories, and expose relevant memory retrieval
- document setup and add pytest coverage for memory endpoints

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement scikit-learn)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c69889e6ec832085b05da5b349186e